### PR TITLE
Removed references to Infinite Red team.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteweb-boilerplate",
-  "description": "React JS version of Ignite Web's hot boilerplate for React Native.",
+  "description": "React JS version of Infinite Red's hot boilerplate for React Native.",
   "license": "MIT",
   "repository": "sidferreira/igniteweb-boilerplate",
   "homepage": "https://github.com/sidferreira/igniteweb-boilerplate",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "igniteweb-boilerplate",
-  "description": "React JS version of Infinite Red's hot boilerplate for React Native.",
+  "description": "React JS version of Ignite Web's hot boilerplate for React Native.",
   "license": "MIT",
   "repository": "sidferreira/igniteweb-boilerplate",
   "homepage": "https://github.com/sidferreira/igniteweb-boilerplate",

--- a/readme.md
+++ b/readme.md
@@ -4,9 +4,9 @@
 
 
 
-## The latest and greatest boilerplate for Infinite Red opinions
+## The latest and greatest boilerplate for our opinions
 
-This is the boilerplate that [Infinite Red](https://infinite.red) uses as a way to test bleeding-edge changes to our React Native stack.
+This is the boilerplate that we use as a way to test bleeding-edge changes to our React Native stack.
 
 Currently includes:
 
@@ -128,4 +128,4 @@ This folder (located as a sibling to `App`) contains sample Jest snapshot and un
 
 ## Premium Support
 
-[Ignite CLI](https://infinite.red/ignite) and [Ignite IR Boilerplate](https://github.com/infinitered/ignite-ir-boilerplate), as open source projects, are free to use and always will be. [Infinite Red](https://infinite.red/) offers premium Ignite CLI support and general mobile app design/development services. Email us at [hello@infinite.red](mailto:hello@infinite.red) to get in touch with us for more details.
+[Ignite CLI](https://infinite.red/ignite) and [Ignite IR Boilerplate](https://github.com/infinitered/ignite-ir-boilerplate), as open source projects, are free to use and always will be.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ## The latest and greatest boilerplate for our opinions
 
-This is the boilerplate that we use as a way to test bleeding-edge changes to our React Native stack.
+This is the boilerplate which is based on [Infinite Red](https://infinite.red)'s Ignite project. We use it as a way to test bleeding-edge changes to our React Web stack.
 
 Currently includes:
 
@@ -128,4 +128,4 @@ This folder (located as a sibling to `App`) contains sample Jest snapshot and un
 
 ## Premium Support
 
-[Ignite CLI](https://infinite.red/ignite) and [Ignite IR Boilerplate](https://github.com/infinitered/ignite-ir-boilerplate), as open source projects, are free to use and always will be.
+[Ignite CLI](https://infinite.red/ignite) and [Ignite IR Boilerplate](https://github.com/infinitered/ignite-ir-boilerplate), as open source projects, are free to use and always will be.  Since this is an open source project the current developers nor Infinite Red offer any premium support for this project at this time.

--- a/readme.md
+++ b/readme.md
@@ -128,4 +128,4 @@ This folder (located as a sibling to `App`) contains sample Jest snapshot and un
 
 ## Premium Support
 
-[Ignite CLI](https://infinite.red/ignite) and [Ignite IR Boilerplate](https://github.com/infinitered/ignite-ir-boilerplate), as open source projects, are free to use and always will be.  Since this is an open source project the current developers nor Infinite Red offer any premium support for this project at this time.
+[Ignite CLI](https://infinite.red/ignite), [Ignite IR Boilerplate](https://github.com/infinitered/ignite-ir-boilerplate) and  [Ignite Web Boilerplate](https://github.com/sidferreira/ignite-web-boilerplate), as open source projects, are free to use and always will be. Since this is an open source project the current developers nor Infinite Red offer any premium support for this project at this time.


### PR DESCRIPTION
I removed all of the references to the Infinite Red Team.  I did not remove any github references or references to infinite red projects currently as we don't have replacement projects to my knowledge.  I figure leaving them as placeholders is more valuable as a skeleton for now then removing them completely.  Would be happy to remove those references too if the team thinks it would be more valuable.